### PR TITLE
ConflictsManager: Add comments for translators

### DIFF
--- a/src/Shortcuts/Backend/ConflictsManager.vala
+++ b/src/Shortcuts/Backend/ConflictsManager.vala
@@ -59,30 +59,53 @@ class Keyboard.Shortcuts.ConflictsManager : GLib.Object {
         // putting this in standard_shortcuts initially doesn't work because we don't create an instance of ConflictsManager
         if (standard_shortcuts == null) {
             standard_shortcuts = {
+                /// The name of Ctrl + C shortcut: "Edit -> Copy"
                 {new Shortcut.parse ("<Ctrl>C"), _("Edit"), _("Copy")},
+                /// The name of Ctrl + V shortcut: "Edit -> Paste"
                 {new Shortcut.parse ("<Ctrl>V"), _("Edit"), _("Paste")},
+                /// The name of Ctrl + X shortcut: "Edit -> Cut"
                 {new Shortcut.parse ("<Ctrl>X"), _("Edit"), _("Cut")},
+                /// The name of Ctrl + Z shortcut: "Edit -> Undo"
                 {new Shortcut.parse ("<Ctrl>Z"), _("Edit"), _("Undo")},
+                /// The name of Ctrl + Y shortcut: "Edit -> Redo"
                 {new Shortcut.parse ("<Ctrl>Y"), _("Edit"), _("Redo")},
+                /// The name of Ctrl + F shortcut: "Edit -> Find"
                 {new Shortcut.parse ("<Ctrl>F"), _("Edit"), _("Find")},
 
+                /// The name of Ctrl + A shortcut: "Selection -> Select All"
                 {new Shortcut.parse ("<Ctrl>A"), _("Selection"), _("Select All")},
+                /// The name of Ctrl + Right shortcut: "Selection -> Move Right by Word"
                 {new Shortcut.parse ("<Shift>Right"), _("Selection"), _("Move Right by Word")},
+                /// The name of Ctrl + Left shortcut: "Selection -> Move Left by Word"
                 {new Shortcut.parse ("<Ctrl>Left"), _("Selection"), _("Move Left by Word")},
+                /// The name of Shift + Right shortcut: "Selection -> Expand Selection"
                 {new Shortcut.parse ("<Shift>Right"), _("Selection"), _("Expand Selection")},
+                /// The name of Shift + Left shortcut: "Selection -> Shrink Selection"
                 {new Shortcut.parse ("<Shift>Left"), _("Selection"), _("Shrink Selection")},
+                /// The name of Shift + Ctrl + Right shortcut: "Selection -> Expand Selection by Word"
                 {new Shortcut.parse ("<Shift><Ctrl>Right"), _("Selection"), _("Expand Selection by Word")},
+                /// The name of Shift + Ctrl + Left shortcut: "Selection -> Shrink Selection by Word"
                 {new Shortcut.parse ("<Shift><Ctrl>Left"), _("Selection"), _("Shrink Selection by Word")},
+                /// The name of Shift + Up shortcut: "Selection -> Expand Selection Up"
                 {new Shortcut.parse ("<Shift>Up"), _("Selection"), _("Expand Selection Up")},
+                /// The name of Shift + Down shortcut: "Selection -> Expand Selection Down"
                 {new Shortcut.parse ("<Shift>Down"), _("Selection"), _("Expand Selection Down")},
 
+                /// The name of Ctrl + S shortcut: "File -> Save"
                 {new Shortcut.parse ("<Ctrl>S"), _("File"), _("Save")},
+                /// The name of Ctrl + Shift + S shortcut: "File -> Save As"
                 {new Shortcut.parse ("<Ctrl><Shift>S"), _("File"), _("Save As")},
+                /// The name of Ctrl + N shortcut: "File -> New"
                 {new Shortcut.parse ("<Ctrl>N"), _("File"), _("New")},
+                /// The name of Ctrl + W shortcut: "File -> Close"
                 {new Shortcut.parse ("<Ctrl>W"), _("File"), _("Close")},
+                /// The name of Ctrl + T shortcut: "File -> New Tab"
                 {new Shortcut.parse ("<Ctrl>T"), _("File"), _("New Tab")},
+                /// The name of Ctrl + Shift + T shortcut: "File -> Restore Closed Tab"
                 {new Shortcut.parse ("<Ctrl><Shift>T"), _("File"), _("Restore Closed Tab")},
-                {new Shortcut.parse ("<Ctrl>R"), _("File"), _("Refresh")},
+                /// The name of Ctrl + R shortcut: "File -> Refresh"
+                {new Shortcut.parse ("<Ctrl>R"), _("File"), C_("keyboard", "Refresh")},
+                /// The name of Ctrl + Q shortcut: "File -> Quit"
                 {new Shortcut.parse ("<Ctrl>Q"), _("File"), _("Quit")},
             };
         }


### PR DESCRIPTION
My main motivation was that we use "Refresh" here as "Refresh", but in System we use it as "Check for updates". And since there's no context, Weblate synchronizes these translations. This branch adds context to this shortcut and also adds comments for translator with explanations on what these shortcut are.